### PR TITLE
Completions

### DIFF
--- a/pkgs/sass_language_server/lib/src/language_server.dart
+++ b/pkgs/sass_language_server/lib/src/language_server.dart
@@ -376,7 +376,7 @@ class LanguageServer {
 
         var configuration = _getLanguageConfiguration(document);
         if (configuration.hover.enabled) {
-          var result = await _ls.doHover(document, params.position);
+          var result = await _ls.hover(document, params.position);
           return result ?? Hover(contents: Either2.t2(""));
         } else {
           return Hover(contents: Either2.t2(""));

--- a/pkgs/sass_language_server/lib/src/language_server.dart
+++ b/pkgs/sass_language_server/lib/src/language_server.dart
@@ -157,6 +157,25 @@ class LanguageServer {
       );
 
       var serverCapabilities = ServerCapabilities(
+        completionProvider: CompletionOptions(
+          resolveProvider: false,
+          triggerCharacters: [
+            // For SassDoc annotation completion
+            "@",
+            "/",
+            // For @use completion
+            '"',
+            "'",
+            // For placeholder completion
+            "%",
+            // For namespaced completions
+            ".",
+            // For property values
+            ":",
+            // For custom properties
+            "-",
+          ],
+        ),
         definitionProvider: Either2.t1(true),
         documentHighlightProvider: Either2.t1(true),
         documentLinkProvider: DocumentLinkOptions(resolveProvider: false),
@@ -327,6 +346,26 @@ class LanguageServer {
     _connection.peer
         .registerMethod('textDocument/documentSymbol', onDocumentSymbol);
 
+    _connection.onCompletion((params) async {
+      try {
+        var document = _documents.get(params.textDocument.uri);
+        if (document == null) {
+          return CompletionList(isIncomplete: true, items: []);
+        }
+
+        var configuration = _getLanguageConfiguration(document);
+        if (configuration.completion.enabled) {
+          var result = await _ls.doComplete(document, params.position);
+          return result;
+        } else {
+          return CompletionList(isIncomplete: true, items: []);
+        }
+      } on Exception catch (e) {
+        _log.debug(e.toString());
+        return CompletionList(isIncomplete: true, items: []);
+      }
+    });
+
     _connection.onHover((params) async {
       try {
         var document = _documents.get(params.textDocument.uri);
@@ -337,7 +376,7 @@ class LanguageServer {
 
         var configuration = _getLanguageConfiguration(document);
         if (configuration.hover.enabled) {
-          var result = await _ls.hover(document, params.position);
+          var result = await _ls.doHover(document, params.position);
           return result ?? Hover(contents: Either2.t2(""));
         } else {
           return Hover(contents: Either2.t2(""));

--- a/pkgs/sass_language_services/lib/src/configuration/language_configuration.dart
+++ b/pkgs/sass_language_services/lib/src/configuration/language_configuration.dart
@@ -7,6 +7,25 @@ class FeatureConfiguration {
   FeatureConfiguration({required this.enabled});
 }
 
+enum MixinStyle { all, noBracket, bracket }
+
+class CompletionConfiguration extends FeatureConfiguration {
+  final bool completePropertyWithSemicolon;
+  final bool css;
+  final MixinStyle mixinStyle;
+  final bool suggestFromUseOnly;
+  final bool triggerPropertyValueCompletion;
+
+  CompletionConfiguration({
+    required super.enabled,
+    required this.completePropertyWithSemicolon,
+    required this.css,
+    required this.mixinStyle,
+    required this.suggestFromUseOnly,
+    required this.triggerPropertyValueCompletion,
+  });
+}
+
 class HoverConfiguration extends FeatureConfiguration {
   final bool documentation;
   final bool references;
@@ -25,6 +44,7 @@ class HoverConfiguration extends FeatureConfiguration {
 /// options to turn off features that cause duplicates or other
 /// interoperability errors.
 class LanguageConfiguration {
+  late final CompletionConfiguration completion;
   late final FeatureConfiguration definition;
   late final FeatureConfiguration documentSymbols;
   late final FeatureConfiguration documentLinks;
@@ -37,6 +57,20 @@ class LanguageConfiguration {
   late final FeatureConfiguration workspaceSymbols;
 
   LanguageConfiguration.from(dynamic config) {
+    completion = CompletionConfiguration(
+      enabled: config?['completion']?['enabled'] as bool? ?? true,
+      completePropertyWithSemicolon:
+          config?['completion']?['completePropertyWithSemicolon'] as bool? ??
+              true,
+      css: config?['completion']?['css'] as bool? ?? true,
+      mixinStyle: _toMixinStyle(config?['completion']?['mixinStyle']),
+      suggestFromUseOnly:
+          config?['completion']?['suggestFromUseOnly'] as bool? ?? true,
+      triggerPropertyValueCompletion:
+          config?['completion']?['triggerPropertyValueCompletion'] as bool? ??
+              true,
+    );
+
     definition = FeatureConfiguration(
         enabled: config?['definition']?['enabled'] as bool? ?? true);
     documentSymbols = FeatureConfiguration(
@@ -62,5 +96,18 @@ class LanguageConfiguration {
         enabled: config?['selectionRanges']?['enabled'] as bool? ?? true);
     workspaceSymbols = FeatureConfiguration(
         enabled: config?['workspaceSymbols']?['enabled'] as bool? ?? true);
+  }
+
+  MixinStyle _toMixinStyle(dynamic style) {
+    var styleString = style as String? ?? 'all';
+    switch (styleString) {
+      case 'nobracket':
+        return MixinStyle.noBracket;
+      case 'bracket':
+        return MixinStyle.bracket;
+      case 'all':
+      default:
+        return MixinStyle.all;
+    }
   }
 }

--- a/pkgs/sass_language_services/lib/src/css/css_property.dart
+++ b/pkgs/sass_language_services/lib/src/css/css_property.dart
@@ -1,6 +1,19 @@
+import 'package:lsp_server/lsp_server.dart' as lsp;
+
+import '../utils/sass_lsp_utils.dart';
 import 'css_value.dart';
 import 'entry_status.dart';
 import 'reference.dart';
+
+final re = RegExp(r'([A-Z]+)(\d+)?');
+const browserNames = {
+  "E": "Edge",
+  "FF": "Firefox",
+  "S": "Safari",
+  "C": "Chrome",
+  "IE": "IE",
+  "O": "Opera",
+};
 
 class CssProperty {
   final String name;
@@ -14,14 +27,65 @@ class CssProperty {
   final int? relevance;
   final String? atRule;
 
-  CssProperty(this.name,
-      {this.description,
-      this.browsers,
-      this.restrictions,
-      this.status,
-      this.syntax,
-      this.values,
-      this.references,
-      this.relevance,
-      this.atRule});
+  CssProperty(
+    this.name, {
+    this.description,
+    this.browsers,
+    this.restrictions,
+    this.status,
+    this.syntax,
+    this.values,
+    this.references,
+    this.relevance,
+    this.atRule,
+  });
+
+  lsp.Either2<lsp.MarkupContent, String> getPlaintextDescription() {
+    var browsersString = browsers?.map<String>((b) {
+      var matches = re.firstMatch(b);
+      if (matches != null) {
+        var browser = matches.group(1);
+        var version = matches.group(2);
+        return "${browserNames[browser]} $version";
+      }
+      return b;
+    }).join(', ');
+
+    var contents = asPlaintext('''
+$description
+
+Syntax: $syntax
+
+$browsersString
+''');
+    return contents;
+  }
+
+  lsp.Either2<lsp.MarkupContent, String> getMarkdownDescription() {
+    var browsersString = browsers?.map<String>((b) {
+      var matches = re.firstMatch(b);
+      if (matches != null) {
+        var browser = matches.group(1);
+        var version = matches.group(2);
+        return "${browserNames[browser]} $version";
+      }
+      return b;
+    }).join(', ');
+
+    var referencesString = references
+        ?.map<String>((r) => '[${r.name}](${r.uri.toString()})')
+        .join('\n');
+
+    var contents = asMarkdown('''
+$description
+
+Syntax: $syntax
+
+$referencesString
+
+$browsersString
+'''
+        .trim());
+    return contents;
+  }
 }

--- a/pkgs/sass_language_services/lib/src/features/completion/completion_context.dart
+++ b/pkgs/sass_language_services/lib/src/features/completion/completion_context.dart
@@ -1,0 +1,27 @@
+import 'package:lsp_server/lsp_server.dart' as lsp;
+import 'package:sass_api/sass_api.dart' as sass;
+import 'package:sass_language_services/sass_language_services.dart';
+
+import '../../configuration/language_configuration.dart';
+
+class CompletionContext {
+  final lsp.Position position;
+  final String currentWord;
+  final String lineBeforePosition;
+  final int offset;
+  final lsp.Range defaultReplaceRange;
+  final TextDocument document;
+  final sass.Stylesheet stylesheet;
+  final CompletionConfiguration configuration;
+
+  CompletionContext({
+    required this.offset,
+    required this.position,
+    required this.currentWord,
+    required this.defaultReplaceRange,
+    required this.document,
+    required this.stylesheet,
+    required this.configuration,
+    required this.lineBeforePosition,
+  });
+}

--- a/pkgs/sass_language_services/lib/src/features/completion/completion_feature.dart
+++ b/pkgs/sass_language_services/lib/src/features/completion/completion_feature.dart
@@ -1,0 +1,200 @@
+import 'package:lsp_server/lsp_server.dart' as lsp;
+import 'package:sass_api/sass_api.dart' as sass;
+import 'package:sass_language_services/sass_language_services.dart';
+
+import '../language_feature.dart';
+import '../node_at_offset_visitor.dart';
+import './completion_context.dart';
+import './completion_list.dart';
+
+class CompletionFeature extends LanguageFeature {
+  CompletionFeature({required super.ls});
+
+  Future<lsp.CompletionList> doComplete(
+      TextDocument document, lsp.Position position) async {
+    var configuration = getLanguageConfiguration(document).completion;
+
+    var offset = document.offsetAt(position);
+    var (lineBeforePosition, currentWord) = _getLineContext(document, offset);
+
+    var defaultReplaceRange = lsp.Range(
+      start: lsp.Position(
+        line: position.line,
+        character: position.character - currentWord.length,
+      ),
+      end: position,
+    );
+
+    var result = CompletionList(
+      isIncomplete: false,
+      items: [],
+      itemDefaults: lsp.CompletionListItemDefaults(
+        editRange: lsp.Either2.t2(defaultReplaceRange),
+      ),
+    );
+
+    var stylesheet = ls.parseStylesheet(document);
+    var path = getNodePathAtOffset(stylesheet, offset);
+
+    var context = CompletionContext(
+      offset: offset,
+      position: position,
+      currentWord: currentWord,
+      defaultReplaceRange: defaultReplaceRange,
+      document: document,
+      configuration: configuration,
+      stylesheet: stylesheet,
+      lineBeforePosition: lineBeforePosition,
+    );
+
+    for (var i = path.length; i >= 0; i--) {
+      var node = path[i];
+      if (node is sass.Declaration) {
+        _declarationCompletion(node, context, result);
+      } else if (node is sass.SimpleSelector) {
+        _selectorCompletion(node, context, result);
+      } else if (node is sass.Interpolation) {
+        var isExtendRule = false;
+        for (var j = i; j >= 0; j--) {
+          var parent = path[j];
+          if (parent is sass.ExtendRule) {
+            isExtendRule = true;
+            break;
+          }
+        }
+        if (isExtendRule) {
+          _extendRuleCompletion(node, context, result);
+        } else {
+          _interpolationCompletion(node, context, result);
+        }
+      } else if (node is sass.ArgumentInvocation) {
+        _argumentInvocationCompletion(node, context, result);
+      } else if (node is sass.StyleRule) {
+        _styleRuleCompletion(node, context, result);
+      } else if (node is sass.PlaceholderSelector) {
+        _placeholderSelectorCompletion(node, context, result);
+      } else if (node is sass.VariableDeclaration) {
+        _variableDeclarationCompletion(node, context, result);
+      } else if (node is sass.FunctionRule) {
+        _functionRuleCompletion(node, context, result);
+      } else if (node is sass.MixinRule) {
+        _mixinRuleCompletion(node, context, result);
+      } else if (node is sass.SupportsRule) {
+        _supportsRuleCompletion(node, context, result);
+      } else if (node is sass.SupportsCondition) {
+        _supportsConditionCompletion(node, context, result);
+      } else if (node is sass.StringExpression) {
+        var isSassDependency = false;
+        var isImportRule = false;
+        for (var j = i; j >= 0; j--) {
+          var parent = path[j];
+          if (parent is sass.SassDependency) {
+            isSassDependency = true;
+            break;
+          } else if (parent is sass.ImportRule) {
+            isImportRule = true;
+            break;
+          }
+        }
+        if (isSassDependency) {
+          await _sassDependencyCompletion(node, context, result);
+        } else if (isImportRule) {
+          await _importRuleCompletion(node, context, result);
+        }
+      } else if (node is sass.SilentComment) {
+        _commentCompletion(node, context, result);
+      } else {
+        continue;
+      }
+
+      if (result.items.isNotEmpty || context.offset > node.span.start.offset) {
+        return _send(result);
+      }
+    }
+
+    _stylesheetCompletion(context, result);
+    return _send(result);
+  }
+
+  lsp.CompletionList _send(CompletionList result) {
+    return lsp.CompletionList(
+      isIncomplete: result.isIncomplete,
+      items: result.items,
+      itemDefaults: result.itemDefaults,
+    );
+  }
+
+  /// Get the current word and the contents of the line before [offset].
+  (String, String) _getLineContext(TextDocument document, int offset) {
+    var text = document.getText();
+
+    // From offset, go back until hitting a newline
+    var i = offset - 1;
+    var codeUnit = text.codeUnitAt(i);
+    const lineFeed = 10; // \n
+    const carriageReturn = 13; // \r
+    while (codeUnit != lineFeed && codeUnit != carriageReturn) {
+      i--;
+      codeUnit = text.codeUnitAt(i);
+    }
+    var lineBeforePosition = text.substring(i + 1, offset);
+
+    // From offset, go back until hitting a word delimiter
+    i = offset - 1;
+    var wordDelimiters = ' \t\n\r":[()]}/,\''.codeUnits;
+    while (i >= 0 && !wordDelimiters.contains(text.codeUnitAt(i))) {
+      i--;
+    }
+    var currentWord = text.substring(i + 1, offset);
+
+    return (lineBeforePosition, currentWord);
+  }
+
+  void _declarationCompletion(sass.Declaration node, CompletionContext context,
+      CompletionList result) {}
+
+  void _interpolationCompletion(sass.Interpolation node,
+      CompletionContext context, CompletionList result) {}
+
+  void _extendRuleCompletion(sass.Interpolation node, CompletionContext context,
+      CompletionList result) {}
+
+  void _selectorCompletion(sass.SimpleSelector node, CompletionContext context,
+      CompletionList result) {}
+
+  void _argumentInvocationCompletion(sass.ArgumentInvocation node,
+      CompletionContext context, CompletionList result) {}
+
+  void _styleRuleCompletion(
+      sass.StyleRule node, CompletionContext context, CompletionList result) {}
+
+  void _variableDeclarationCompletion(sass.VariableDeclaration node,
+      CompletionContext context, CompletionList result) {}
+
+  void _functionRuleCompletion(sass.FunctionRule node,
+      CompletionContext context, CompletionList result) {}
+
+  void _mixinRuleCompletion(
+      sass.MixinRule node, CompletionContext context, CompletionList result) {}
+
+  void _supportsRuleCompletion(sass.SupportsRule node,
+      CompletionContext context, CompletionList result) {}
+
+  void _supportsConditionCompletion(sass.SupportsCondition node,
+      CompletionContext context, CompletionList result) {}
+
+  Future<void> _sassDependencyCompletion(sass.StringExpression node,
+      CompletionContext context, CompletionList result) async {}
+
+  Future<void> _importRuleCompletion(sass.StringExpression node,
+      CompletionContext context, CompletionList result) async {}
+
+  void _stylesheetCompletion(
+      CompletionContext context, CompletionList result) {}
+
+  void _commentCompletion(sass.SilentComment node, CompletionContext context,
+      CompletionList result) {}
+
+  void _placeholderSelectorCompletion(sass.PlaceholderSelector node,
+      CompletionContext context, CompletionList result) {}
+}

--- a/pkgs/sass_language_services/lib/src/features/completion/completion_list.dart
+++ b/pkgs/sass_language_services/lib/src/features/completion/completion_list.dart
@@ -1,0 +1,14 @@
+import 'package:lsp_server/lsp_server.dart' as lsp;
+
+/// A mutable variant of [lsp.CompletionList].
+class CompletionList {
+  bool isIncomplete;
+  List<lsp.CompletionItem> items;
+  lsp.CompletionListItemDefaults itemDefaults;
+
+  CompletionList({
+    required this.isIncomplete,
+    required this.itemDefaults,
+    required this.items,
+  });
+}

--- a/pkgs/sass_language_services/lib/src/features/language_feature.dart
+++ b/pkgs/sass_language_services/lib/src/features/language_feature.dart
@@ -4,6 +4,8 @@ import 'package:lsp_server/lsp_server.dart' as lsp;
 import 'package:sass_api/sass_api.dart' as sass;
 
 import '../../sass_language_services.dart';
+import '../css/css_data.dart';
+import '../sass/sass_data.dart';
 import '../utils/uri_utils.dart';
 import 'node_at_offset_visitor.dart';
 
@@ -15,7 +17,16 @@ class WorkspaceResult<T> {
 }
 
 abstract class LanguageFeature {
+  final cssData = CssData();
+  final sassData = SassData();
+
   late final LanguageServices ls;
+
+  bool supportsMarkdown() =>
+      ls.clientCapabilities.textDocument?.hover?.contentFormat
+              ?.any((f) => f == lsp.MarkupKind.Markdown) ==
+          true ||
+      ls.clientCapabilities.general?.markdown != null;
 
   LanguageFeature({required this.ls});
 

--- a/pkgs/sass_language_services/lib/src/language_services.dart
+++ b/pkgs/sass_language_services/lib/src/language_services.dart
@@ -1,6 +1,7 @@
 import 'package:lsp_server/lsp_server.dart' as lsp;
 import 'package:sass_api/sass_api.dart' as sass;
 import 'package:sass_language_services/sass_language_services.dart';
+import 'package:sass_language_services/src/features/completion/completion_feature.dart';
 import 'package:sass_language_services/src/features/document_highlights/document_highlights_feature.dart';
 import 'package:sass_language_services/src/features/find_references/find_references_feature.dart';
 import 'package:sass_language_services/src/features/folding_ranges/folding_ranges_feature.dart';
@@ -27,6 +28,7 @@ class LanguageServices {
   LanguageServerConfiguration configuration =
       LanguageServerConfiguration.create(null);
 
+  late final CompletionFeature _completion;
   late final DocumentHighlightsFeature _documentHighlights;
   late final DocumentLinksFeature _documentLinks;
   late final DocumentSymbolsFeature _documentSymbols;
@@ -42,6 +44,7 @@ class LanguageServices {
     required this.clientCapabilities,
     required this.fs,
   }) : cache = LanguageServicesCache() {
+    _completion = CompletionFeature(ls: this);
     _documentHighlights = DocumentHighlightsFeature(ls: this);
     _documentLinks = DocumentLinksFeature(ls: this);
     _documentSymbols = DocumentSymbolsFeature(ls: this);
@@ -56,6 +59,14 @@ class LanguageServices {
 
   void configure(LanguageServerConfiguration configuration) {
     this.configuration = configuration;
+  }
+
+  /// Get a response for the [completion proposal](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocument_completion) request.
+  ///
+  /// Editors use this response to show relevant suggestions when typing.
+  Future<lsp.CompletionList> doComplete(
+      TextDocument document, lsp.Position position) {
+    return _completion.doComplete(document, position);
   }
 
   /// Get a response for the [document highlights](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocument_documentHighlight) request.

--- a/pkgs/sass_language_services/lib/src/utils/sass_lsp_utils.dart
+++ b/pkgs/sass_language_services/lib/src/utils/sass_lsp_utils.dart
@@ -63,3 +63,21 @@ bool isSameRange(lsp.Range a, lsp.Range b) {
       a.end.line == b.end.line &&
       a.end.character == b.end.character;
 }
+
+lsp.Either2<lsp.MarkupContent, String> asMarkdown(String content) {
+  return lsp.Either2.t1(
+    lsp.MarkupContent(
+      kind: lsp.MarkupKind.Markdown,
+      value: content,
+    ),
+  );
+}
+
+lsp.Either2<lsp.MarkupContent, String> asPlaintext(String content) {
+  return lsp.Either2.t1(
+    lsp.MarkupContent(
+      kind: lsp.MarkupKind.PlainText,
+      value: content,
+    ),
+  );
+}

--- a/pkgs/sass_language_services/test/features/completion/completion_test.dart
+++ b/pkgs/sass_language_services/test/features/completion/completion_test.dart
@@ -84,7 +84,23 @@ void main() {
       ls.cache.clear();
     });
 
-    test('in an empty style rule', () async {
+    // TODO: The parser throws if the stylesheet is not valid which makes implementing completions a bit tricky.
+    // Error: Expected expression.
+    //    ╷
+    //  2 │   display: ;
+    //    │            ^
+    //    ╵
+    //    - 2:12  root stylesheet
+    //  package:sass/src/utils.dart 428:3                                                     throwWithTrace
+    //  package:sass/src/parse/parser.dart 732:7                                              Parser.wrapSpanFormatException
+    //  package:sass/src/parse/stylesheet.dart 86:12                                          StylesheetParser.parse
+    //  package:sass/src/ast/sass/statement/stylesheet.dart 134:38                            new Stylesheet.parseScss
+    //  package:sass_language_services/src/language_services_cache.dart 35:38                 LanguageServicesCache.getStylesheet
+    //  package:sass_language_services/src/language_services.dart 106:18                      LanguageServices.parseStylesheet
+    //  package:sass_language_services/src/features/completion/completion_feature.dart 52:25  CompletionFeature.doComplete
+    //  package:sass_language_services/src/language_services.dart 61:24                       LanguageServices.doComplete
+    //  test/features/completion/completion_test.dart 94:29                                   main.<fn>.<fn>
+    test('for display', () async {
       var document = fs.createDocument(r'''
 .a {
   display: ;

--- a/pkgs/sass_language_services/test/features/completion/completion_test.dart
+++ b/pkgs/sass_language_services/test/features/completion/completion_test.dart
@@ -1,0 +1,105 @@
+import 'package:lsp_server/lsp_server.dart' as lsp;
+import 'package:sass_language_services/sass_language_services.dart';
+import 'package:test/test.dart';
+
+import '../../memory_file_system.dart';
+import '../../position_utils.dart';
+import '../../test_client_capabilities.dart';
+
+final fs = MemoryFileSystem();
+final ls = LanguageServices(fs: fs, clientCapabilities: getCapabilities());
+
+void hasEntry(lsp.CompletionList result, String label) {
+  expect(
+    result.items.any((i) => i.label == label),
+    isTrue,
+    reason: 'Expected to find an entry with the label $label',
+  );
+}
+
+void hasNoEntry(lsp.CompletionList result, String label) {
+  expect(
+    result.items.every((i) => i.label != label),
+    isTrue,
+    reason: 'Did not expect to find an entry with the label $label',
+  );
+}
+
+void main() {
+  group('CSS declarations', () {
+    setUp(() {
+      ls.cache.clear();
+    });
+
+    test('in an empty style rule', () async {
+      var document = fs.createDocument(r'''
+.a {  }
+''');
+      var result = await ls.doComplete(document, at(line: 0, char: 5));
+
+      expect(result.items, isNotEmpty);
+      hasEntry(result, 'display');
+      hasEntry(result, 'font-size');
+    });
+
+    test('in an empty style rule for indented', () async {
+      var document = fs.createDocument(r'''
+.a
+    // Here to stop removing trailing whitespace
+''', uri: 'indented.sass');
+      var result = await ls.doComplete(document, at(line: 1, char: 2));
+
+      expect(result.items, isNotEmpty);
+      hasEntry(result, 'display');
+      hasEntry(result, 'font-size');
+    });
+
+    test('in style rule with other declarations', () async {
+      var document = fs.createDocument(r'''
+.a
+  display: block
+   // Here to stop removing trailing whitespace
+''', uri: 'indented.sass');
+      var result = await ls.doComplete(document, at(line: 2, char: 2));
+
+      expect(result.items, isNotEmpty);
+      hasEntry(result, 'display');
+      hasEntry(result, 'font-size');
+    });
+
+    test('not outside of a style rule', () async {
+      var document = fs.createDocument(r'''
+
+.a {  }
+''');
+      var result = await ls.doComplete(document, at(line: 0, char: 0));
+
+      hasNoEntry(result, 'display');
+      hasNoEntry(result, 'font-size');
+    });
+  });
+
+  group('CSS declaration values', () {
+    setUp(() {
+      ls.cache.clear();
+    });
+
+    test('in an empty style rule', () async {
+      var document = fs.createDocument(r'''
+.a {
+  display: ;
+}
+''');
+      var result = await ls.doComplete(document, at(line: 1, char: 11));
+
+      expect(result.items, isNotEmpty);
+
+      hasEntry(result, 'block');
+
+      // Should not suggest new declarations
+      // or irrelevant values.
+      hasNoEntry(result, 'display');
+      hasNoEntry(result, 'bottom'); // vertical-align value
+    });
+  });
+}

--- a/pkgs/sass_language_services/test/features/hover/hover_test.dart
+++ b/pkgs/sass_language_services/test/features/hover/hover_test.dart
@@ -46,7 +46,7 @@ nav {
     }
 }
 ''');
-      var result = await ls.doHover(document, at(line: 1, char: 5));
+      var result = await ls.hover(document, at(line: 1, char: 5));
 
       expect(result, isNotNull);
       expect(getContents(result), contains('nav ul'));
@@ -60,7 +60,7 @@ nav {
   padding: 0;
 }
 ''');
-      var result = await ls.doHover(document, at(line: 0, char: 2));
+      var result = await ls.hover(document, at(line: 0, char: 2));
 
       expect(result, isNotNull);
       expect(getContents(result), contains(':has(.foo)'));
@@ -74,7 +74,7 @@ nav {
   padding: 0;
 }
 ''');
-      var result = await ls.doHover(document, at(line: 0, char: 2));
+      var result = await ls.hover(document, at(line: 0, char: 2));
 
       expect(result, isNotNull);
       expect(getContents(result), contains(':has(#bar)'));
@@ -94,7 +94,7 @@ nav {
   padding: 0;
 }
 ''');
-      var result = await ls.doHover(document, at(line: 1, char: 3));
+      var result = await ls.hover(document, at(line: 1, char: 3));
 
       expect(result, isNotNull);
       expect(getContents(result), contains('margin'));
@@ -115,7 +115,7 @@ nav {
     }
 }
 ''');
-      var result = await ls.doHover(document, at(line: 1, char: 5));
+      var result = await ls.hover(document, at(line: 1, char: 5));
 
       expect(result, isNotNull);
       expect(getContents(result), contains('.button--primary'));
@@ -133,7 +133,7 @@ nav {
   }
 }
 ''');
-      var result = await ls.doHover(document, at(line: 2, char: 10));
+      var result = await ls.hover(document, at(line: 2, char: 10));
 
       expect(result, isNotNull);
       expect(getContents(result), contains('.button--primary::hover'));
@@ -155,7 +155,7 @@ nav {
   }
 }
 ''');
-      var result = await ls.doHover(document, at(line: 6, char: 10));
+      var result = await ls.hover(document, at(line: 6, char: 10));
 
       expect(result, isNotNull);
       expect(getContents(result),
@@ -175,7 +175,7 @@ nav {
 }
 ''');
 
-      var result = await ls.doHover(document, at(line: 3, char: 24));
+      var result = await ls.hover(document, at(line: 3, char: 24));
 
       expect(result, isNotNull);
       expect(
@@ -200,7 +200,7 @@ $_button-border-width: rem(1px);
 }
 ''');
 
-      var result = await ls.doHover(document, at(line: 3, char: 23));
+      var result = await ls.hover(document, at(line: 3, char: 23));
 
       expect(result, isNotNull);
       expect(getContents(result), contains(r'$_button-border-width: rem(1px)'));
@@ -223,7 +223,7 @@ $border-width: rem(1px);
 }
 ''');
 
-      var result = await ls.doHover(document, at(line: 3, char: 23));
+      var result = await ls.hover(document, at(line: 3, char: 23));
 
       expect(result, isNotNull);
       expect(getContents(result), contains(r'$button-border-width: rem(1px)'));
@@ -246,7 +246,7 @@ $border-width: rem(1px);
 }
 ''');
 
-      var result = await ls.doHover(document, at(line: 5, char: 14));
+      var result = await ls.hover(document, at(line: 5, char: 14));
 
       expect(result, isNotNull);
       expect(getContents(result), contains(r'@function getPrimary()'));
@@ -261,7 +261,7 @@ $border-width: rem(1px);
 @debug compare($b: 2);
 ''');
 
-      var result = await ls.doHover(document, at(line: 4, char: 9));
+      var result = await ls.hover(document, at(line: 4, char: 9));
 
       expect(result, isNotNull);
       expect(getContents(result), contains(r'@function compare($a: 1, $b)'));
@@ -280,7 +280,7 @@ $border-width: rem(1px);
 @debug core.compare($b: 2);
 ''');
 
-      var result = await ls.doHover(document, at(line: 2, char: 9));
+      var result = await ls.hover(document, at(line: 2, char: 9));
 
       expect(result, isNotNull);
       expect(getContents(result), contains(r'@function compare($a: 1, $b)'));
@@ -303,7 +303,7 @@ $border-width: rem(1px);
 @debug core.math-compare($b: 2);
 ''');
 
-      var result = await ls.doHover(document, at(line: 2, char: 19));
+      var result = await ls.hover(document, at(line: 2, char: 19));
 
       expect(result, isNotNull);
       expect(
@@ -327,7 +327,7 @@ $border-width: rem(1px);
 }
 ''');
 
-      var result = await ls.doHover(document, at(line: 5, char: 14));
+      var result = await ls.hover(document, at(line: 5, char: 14));
 
       expect(result, isNotNull);
       expect(getContents(result), contains(r'@mixin primary'));
@@ -344,7 +344,7 @@ $border-width: rem(1px);
 }
 ''');
 
-      var result = await ls.doHover(document, at(line: 5, char: 14));
+      var result = await ls.hover(document, at(line: 5, char: 14));
 
       expect(result, isNotNull);
       expect(getContents(result), contains(r'@mixin theme($base: green)'));
@@ -365,7 +365,7 @@ $border-width: rem(1px);
 }
 ''');
 
-      var result = await ls.doHover(document, at(line: 3, char: 19));
+      var result = await ls.hover(document, at(line: 3, char: 19));
 
       expect(result, isNotNull);
       expect(getContents(result), contains(r'@mixin theme($base: green)'));
@@ -390,7 +390,7 @@ $border-width: rem(1px);
 }
 ''');
 
-      var result = await ls.doHover(document, at(line: 3, char: 19));
+      var result = await ls.hover(document, at(line: 3, char: 19));
 
       expect(result, isNotNull);
       expect(
@@ -410,7 +410,7 @@ $border-width: rem(1px);
 @debug math.$pi;
 ''');
 
-      var result = await ls.doHover(document, at(line: 2, char: 14));
+      var result = await ls.hover(document, at(line: 2, char: 14));
       expect(result, isNotNull);
       expect(getContents(result), contains('π'));
       expect(getContents(result), contains('sass-lang.com'));
@@ -423,7 +423,7 @@ $border-width: rem(1px);
 @debug math.ceil(4);
 ''');
 
-      var result = await ls.doHover(document, at(line: 2, char: 14));
+      var result = await ls.hover(document, at(line: 2, char: 14));
       expect(result, isNotNull);
       expect(getContents(result),
           contains('Rounds up to the nearest whole number'));
@@ -437,7 +437,7 @@ $border-width: rem(1px);
 $_id: string.unique-id();
 ''');
 
-      var result = await ls.doHover(document, at(line: 2, char: 14));
+      var result = await ls.hover(document, at(line: 2, char: 14));
       expect(result, isNotNull);
       expect(getContents(result),
           contains('Returns a randomly-generated unquoted string'));

--- a/pkgs/sass_language_services/test/features/hover/hover_test.dart
+++ b/pkgs/sass_language_services/test/features/hover/hover_test.dart
@@ -46,7 +46,7 @@ nav {
     }
 }
 ''');
-      var result = await ls.hover(document, at(line: 1, char: 5));
+      var result = await ls.doHover(document, at(line: 1, char: 5));
 
       expect(result, isNotNull);
       expect(getContents(result), contains('nav ul'));
@@ -60,7 +60,7 @@ nav {
   padding: 0;
 }
 ''');
-      var result = await ls.hover(document, at(line: 0, char: 2));
+      var result = await ls.doHover(document, at(line: 0, char: 2));
 
       expect(result, isNotNull);
       expect(getContents(result), contains(':has(.foo)'));
@@ -74,7 +74,7 @@ nav {
   padding: 0;
 }
 ''');
-      var result = await ls.hover(document, at(line: 0, char: 2));
+      var result = await ls.doHover(document, at(line: 0, char: 2));
 
       expect(result, isNotNull);
       expect(getContents(result), contains(':has(#bar)'));
@@ -94,7 +94,7 @@ nav {
   padding: 0;
 }
 ''');
-      var result = await ls.hover(document, at(line: 1, char: 3));
+      var result = await ls.doHover(document, at(line: 1, char: 3));
 
       expect(result, isNotNull);
       expect(getContents(result), contains('margin'));
@@ -115,7 +115,7 @@ nav {
     }
 }
 ''');
-      var result = await ls.hover(document, at(line: 1, char: 5));
+      var result = await ls.doHover(document, at(line: 1, char: 5));
 
       expect(result, isNotNull);
       expect(getContents(result), contains('.button--primary'));
@@ -133,7 +133,7 @@ nav {
   }
 }
 ''');
-      var result = await ls.hover(document, at(line: 2, char: 10));
+      var result = await ls.doHover(document, at(line: 2, char: 10));
 
       expect(result, isNotNull);
       expect(getContents(result), contains('.button--primary::hover'));
@@ -155,7 +155,7 @@ nav {
   }
 }
 ''');
-      var result = await ls.hover(document, at(line: 6, char: 10));
+      var result = await ls.doHover(document, at(line: 6, char: 10));
 
       expect(result, isNotNull);
       expect(getContents(result),
@@ -175,7 +175,7 @@ nav {
 }
 ''');
 
-      var result = await ls.hover(document, at(line: 3, char: 24));
+      var result = await ls.doHover(document, at(line: 3, char: 24));
 
       expect(result, isNotNull);
       expect(
@@ -200,7 +200,7 @@ $_button-border-width: rem(1px);
 }
 ''');
 
-      var result = await ls.hover(document, at(line: 3, char: 23));
+      var result = await ls.doHover(document, at(line: 3, char: 23));
 
       expect(result, isNotNull);
       expect(getContents(result), contains(r'$_button-border-width: rem(1px)'));
@@ -223,7 +223,7 @@ $border-width: rem(1px);
 }
 ''');
 
-      var result = await ls.hover(document, at(line: 3, char: 23));
+      var result = await ls.doHover(document, at(line: 3, char: 23));
 
       expect(result, isNotNull);
       expect(getContents(result), contains(r'$button-border-width: rem(1px)'));
@@ -246,7 +246,7 @@ $border-width: rem(1px);
 }
 ''');
 
-      var result = await ls.hover(document, at(line: 5, char: 14));
+      var result = await ls.doHover(document, at(line: 5, char: 14));
 
       expect(result, isNotNull);
       expect(getContents(result), contains(r'@function getPrimary()'));
@@ -261,7 +261,7 @@ $border-width: rem(1px);
 @debug compare($b: 2);
 ''');
 
-      var result = await ls.hover(document, at(line: 4, char: 9));
+      var result = await ls.doHover(document, at(line: 4, char: 9));
 
       expect(result, isNotNull);
       expect(getContents(result), contains(r'@function compare($a: 1, $b)'));
@@ -280,7 +280,7 @@ $border-width: rem(1px);
 @debug core.compare($b: 2);
 ''');
 
-      var result = await ls.hover(document, at(line: 2, char: 9));
+      var result = await ls.doHover(document, at(line: 2, char: 9));
 
       expect(result, isNotNull);
       expect(getContents(result), contains(r'@function compare($a: 1, $b)'));
@@ -303,7 +303,7 @@ $border-width: rem(1px);
 @debug core.math-compare($b: 2);
 ''');
 
-      var result = await ls.hover(document, at(line: 2, char: 19));
+      var result = await ls.doHover(document, at(line: 2, char: 19));
 
       expect(result, isNotNull);
       expect(
@@ -327,7 +327,7 @@ $border-width: rem(1px);
 }
 ''');
 
-      var result = await ls.hover(document, at(line: 5, char: 14));
+      var result = await ls.doHover(document, at(line: 5, char: 14));
 
       expect(result, isNotNull);
       expect(getContents(result), contains(r'@mixin primary'));
@@ -344,7 +344,7 @@ $border-width: rem(1px);
 }
 ''');
 
-      var result = await ls.hover(document, at(line: 5, char: 14));
+      var result = await ls.doHover(document, at(line: 5, char: 14));
 
       expect(result, isNotNull);
       expect(getContents(result), contains(r'@mixin theme($base: green)'));
@@ -365,7 +365,7 @@ $border-width: rem(1px);
 }
 ''');
 
-      var result = await ls.hover(document, at(line: 3, char: 19));
+      var result = await ls.doHover(document, at(line: 3, char: 19));
 
       expect(result, isNotNull);
       expect(getContents(result), contains(r'@mixin theme($base: green)'));
@@ -390,7 +390,7 @@ $border-width: rem(1px);
 }
 ''');
 
-      var result = await ls.hover(document, at(line: 3, char: 19));
+      var result = await ls.doHover(document, at(line: 3, char: 19));
 
       expect(result, isNotNull);
       expect(
@@ -410,7 +410,7 @@ $border-width: rem(1px);
 @debug math.$pi;
 ''');
 
-      var result = await ls.hover(document, at(line: 2, char: 14));
+      var result = await ls.doHover(document, at(line: 2, char: 14));
       expect(result, isNotNull);
       expect(getContents(result), contains('π'));
       expect(getContents(result), contains('sass-lang.com'));
@@ -423,7 +423,7 @@ $border-width: rem(1px);
 @debug math.ceil(4);
 ''');
 
-      var result = await ls.hover(document, at(line: 2, char: 14));
+      var result = await ls.doHover(document, at(line: 2, char: 14));
       expect(result, isNotNull);
       expect(getContents(result),
           contains('Rounds up to the nearest whole number'));
@@ -437,7 +437,7 @@ $border-width: rem(1px);
 $_id: string.unique-id();
 ''');
 
-      var result = await ls.hover(document, at(line: 2, char: 14));
+      var result = await ls.doHover(document, at(line: 2, char: 14));
       expect(result, isNotNull);
       expect(getContents(result),
           contains('Returns a randomly-generated unquoted string'));


### PR DESCRIPTION
Sets up the server capability and a handler for [completion requests](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocument_completion).

I've run into an issue with how strict the current parser is:
https://github.com/sass/dart-sass-language-server/pull/34/files#diff-dfd87bf70431e0c34c7d859b41e81359474d0cff8488684c8796738aed0c3e72R87-R120

```css
.a {
  display: /* [1] */ ;
}

/* [1] Here the parser throws (Error: Expected expression).
   Since we don't have a Stylesheet we can't tell what the context/AstNode is at this position.
   We would like to know that we're in a Declaration with the name "display", with no children,
   so we can provide completion items for the allowed values for the display property.

   In this particular case we could probably work around it by looking at the raw string,
   but strings have their own limitations and problems (how to handle scope for Sass variables
   for instance). */
```

It makes perfect sense for a compiler to be this strict, but (especially for this feature) the language server needs the parser to run in a mode where it does its best to recover from these errors and returns the `Stylesheet` in whatever state it currently is, errors and all.